### PR TITLE
feat: Allow specifying output subfolder for renamed clips

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -301,12 +301,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const selectedCheckboxes = folderListContainer.querySelectorAll('input[type="checkbox"]:checked');
         const selectedFolders = Array.from(selectedCheckboxes).map(cb => cb.value);
+        const outputSubfolderName = document.getElementById('outputSubfolderName').value.trim();
 
         renameFeedback.innerHTML = '';
         renameFeedback.className = 'mt-3'; // Reset class
 
         if (selectedFolders.length === 0) {
             renameFeedback.textContent = 'Please select at least one folder.';
+            renameFeedback.classList.add('alert', 'alert-warning');
+            return;
+        }
+
+        if (!outputSubfolderName) {
+            renameFeedback.textContent = 'Please enter a name for the output subfolder.';
             renameFeedback.classList.add('alert', 'alert-warning');
             return;
         }
@@ -321,7 +328,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ selectedFolders }),
+                body: JSON.stringify({ selectedFolders, outputSubfolder: outputSubfolderName }),
             });
 
             const result = await response.json();

--- a/public/index.html
+++ b/public/index.html
@@ -229,6 +229,11 @@
                     <div id="folder-list-container" class="mb-3">
                         <!-- Las carpetas se cargarán aquí -->
                     </div>
+                    <div class="mb-3">
+                        <label for="outputSubfolderName" class="form-label">Nombre de la carpeta de salida:</label>
+                        <input type="text" class="form-control" id="outputSubfolderName" placeholder="Ej: nuevosNombres">
+                        <div class="form-text">Este nombre se usará para crear una subcarpeta dentro de 'output/random_names'.</div>
+                    </div>
                     <button id="rename-button" class="btn btn-success">
                         <i class="bi bi-pencil-square"></i> Renombrar Clips Seleccionados
                     </button>

--- a/src/app.ts
+++ b/src/app.ts
@@ -375,7 +375,7 @@ export class SakugaDownAndClipGen {
 
     // Handler for renaming videos using the Python script
     private handleRenameVideos(req: express.Request, res: express.Response): void {
-        const { selectedFolders } = req.body;
+        const { selectedFolders, outputSubfolder } = req.body;
 
         if (!selectedFolders || !Array.isArray(selectedFolders) || selectedFolders.length === 0) {
             res.status(400).json({
@@ -385,9 +385,17 @@ export class SakugaDownAndClipGen {
             return;
         }
 
+        if (!outputSubfolder || typeof outputSubfolder !== 'string' || outputSubfolder.trim() === '') {
+            res.status(400).json({
+                status: "error",
+                message: "Invalid request body. 'outputSubfolder' is required and must be a non-empty string."
+            });
+            return;
+        }
+
         const clipsBaseDir = this.clipDirectory; // output/clips
         const inputDirs = selectedFolders.map(folder => path.join(clipsBaseDir, folder));
-        const outputDir = path.join('output', 'random_names'); // output/random_names
+        const outputDir = path.join('output', 'random_names', outputSubfolder.trim()); // output/random_names
 
         // Ensure output directory for the script exists, though the script should also handle this
         try {


### PR DESCRIPTION
This commit introduces the ability for you to specify a subfolder name when renaming clips. The new subfolder will be created inside the existing 'output/random_names/' directory.

Changes include:
- Added an input field in `public/index.html` for you to enter the desired subfolder name.
- Modified `public/app.js` to read this input, validate it, and send it to the backend API.
- Updated `src/app.ts` to receive the subfolder name, validate it, and construct the full output path for the `rename_clips.py` script.

The `rename_clips.py` script already supported a custom output directory, and this change leverages that by allowing the backend to specify a more precise path.