### PR TITLE
feat: Add filter and select all/deselect all to clip renaming

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -220,6 +220,11 @@
                         Selecciona las carpetas de clips que deseas procesar. Los videos MP4 dentro de estas carpetas (y sus subcarpetas)
                         serán copiados a una nueva ubicación ('output/random_names') con nombres aleatorios de 20 dígitos.
                     </p>
+                    <input type="text" class="form-control mb-2" id="folderFilterInput" placeholder="Filtrar carpetas...">
+                    <div class="mb-3 btn-group btn-group-sm">
+                        <button type="button" class="btn btn-outline-secondary" id="selectAllFoldersBtn">Seleccionar Todo</button>
+                        <button type="button" class="btn btn-outline-secondary" id="deselectAllFoldersBtn">Desmarcar Todo</button>
+                    </div>
                     <div id="folder-loading-indicator" class="alert alert-info" role="alert">
                         <div class="spinner-border spinner-border-sm" role="status">
                             <span class="visually-hidden">Loading...</span>


### PR DESCRIPTION
I've implemented new features in the "Renombrar Clips" section for you:

- Folder Filtering: I added a text input field that allows you to filter the list of clip folders dynamically. The list updates as you type, providing a quick way to find specific folders.
- Select All: I added a "Seleccionar Todo" button that selects all currently visible (filtered) folders in the list.
- Deselect All: I added a "Desmarcar Todo" button that deselects all currently visible (filtered) folders.

These changes improve the usability of the clip renaming section, especially when you are dealing with a large number of clip folders.