### PR TITLE
Fix FFmpeg path lookup on non‑Windows platforms

### DIFF
--- a/dist/clipGenerator/index.js
+++ b/dist/clipGenerator/index.js
@@ -67,11 +67,12 @@ function isExecutableAvailable(executableName) {
 }
 // Intentar buscar FFmpeg de manera más exhaustiva
 function findFFmpegPath() {
-    // Verificar si está en el PATH
+    // Verificar si ffmpeg está disponible en el PATH
     if (isExecutableAvailable('ffmpeg')) {
         try {
-            const output = (0, child_process_2.execSync)('where ffmpeg', { encoding: 'utf8' }).trim();
-            const paths = output.split('\n');
+            const cmd = process.platform === 'win32' ? 'where ffmpeg' : 'which ffmpeg';
+            const output = (0, child_process_2.execSync)(cmd, { encoding: 'utf8' }).trim();
+            const paths = output.split(/\r?\n/);
             if (paths.length > 0) {
                 return paths[0].trim();
             }

--- a/src/clipGenerator/index.ts
+++ b/src/clipGenerator/index.ts
@@ -32,11 +32,12 @@ function isExecutableAvailable(executableName: string): boolean {
 
 // Intentar buscar FFmpeg de manera más exhaustiva
 function findFFmpegPath(): string | null {
-    // Verificar si está en el PATH
+    // Verificar si ffmpeg está disponible en el PATH
     if (isExecutableAvailable('ffmpeg')) {
         try {
-            const output = execSync('where ffmpeg', { encoding: 'utf8' }).trim();
-            const paths = output.split('\n');
+            const cmd = process.platform === 'win32' ? 'where ffmpeg' : 'which ffmpeg';
+            const output = execSync(cmd, { encoding: 'utf8' }).trim();
+            const paths = output.split(/\r?\n/);
             if (paths.length > 0) {
                 return paths[0].trim();
             }


### PR DESCRIPTION
## Summary
- fix FFmpeg detection by using `which` on Unix
- rebuild compiled files

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f4927c25c83238adb4d1199e8f8b7