### PR TITLE
Add delete video option

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -173,6 +173,8 @@ class SakugaDownAndClipGen {
         this.app.post('/api/download-and-clip', this.handlePostDownloadAndClip.bind(this));
         // API para eliminar un clip
         this.app.post('/api/delete-clip', this.handlePostDeleteClip.bind(this));
+        // API para eliminar un video descargado
+        this.app.post('/api/delete-video', this.handlePostDeleteVideo.bind(this));
         // API for listing clip folders and renaming videos
         this.app.get('/api/clips/list-folders', this.handleListClipFolders.bind(this));
         this.app.post('/api/clips/rename-videos', this.handleRenameVideos.bind(this));
@@ -553,6 +555,54 @@ class SakugaDownAndClipGen {
             }
             catch (error) {
                 console.error('Error al eliminar clip:', error);
+                res.status(500).json({ error: error.message });
+            }
+        });
+    }
+    /**
+     * Maneja la solicitud para eliminar un video descargado
+     */
+    handlePostDeleteVideo(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const { videoPath } = req.body;
+                if (!videoPath) {
+                    res.status(400).json({ error: 'Se requiere la ruta del video a eliminar' });
+                    return;
+                }
+                const fullPath = path.join(this.downloadDirectory, videoPath);
+                console.log(`Intentando eliminar video: ${fullPath}`);
+                if (!fs.existsSync(fullPath)) {
+                    res.status(404).json({ error: 'Video no encontrado' });
+                    return;
+                }
+                const normalizedDir = path.normalize(this.downloadDirectory);
+                const normalizedFullPath = path.normalize(fullPath);
+                if (!normalizedFullPath.startsWith(normalizedDir)) {
+                    res.status(403).json({ error: 'Acceso denegado: ruta de archivo no permitida' });
+                    return;
+                }
+                fs.unlinkSync(fullPath);
+                console.log(`Video eliminado: ${videoPath}`);
+                const videoDir = path.dirname(fullPath);
+                if (fs.existsSync(videoDir) && videoDir !== this.downloadDirectory) {
+                    const remaining = fs.readdirSync(videoDir);
+                    if (remaining.length === 0) {
+                        try {
+                            fs.rmdirSync(videoDir);
+                            console.log(`Carpeta vacía eliminada: ${videoDir}`);
+                        }
+                        catch (e) {
+                            console.warn(`No se pudo eliminar la carpeta vacía: ${videoDir}`, e);
+                        }
+                    }
+                }
+                const downloads = this.getDirectoryContents(this.downloadDirectory);
+                this.io.emit('directoriesUpdated', { type: 'downloads', contents: downloads });
+                res.json({ success: true, message: 'Video eliminado correctamente' });
+            }
+            catch (error) {
+                console.error('Error al eliminar video:', error);
                 res.status(500).json({ error: error.message });
             }
         });

--- a/public/app.js
+++ b/public/app.js
@@ -879,7 +879,16 @@ function displayDownloadedVideos(videos) {
                     openVideoPlayer(`/downloads/${video.path}`, video.name);
                 });
 
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'btn btn-sm btn-danger ms-2';
+                deleteBtn.innerHTML = '<i class="bi bi-trash"></i>';
+                deleteBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    deleteVideo(video.path);
+                });
+
                 videoItem.appendChild(playBtn);
+                videoItem.appendChild(deleteBtn);
                 videoList.appendChild(videoItem);
             });
 
@@ -905,6 +914,15 @@ function displayDownloadedVideos(videos) {
                 videoPreview.className = 'video-thumbnail d-flex justify-content-center align-items-center bg-dark text-white';
                 videoPreview.innerHTML = '<i class="bi bi-play-circle fs-1"></i>';
 
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'delete-video-btn';
+                deleteBtn.innerHTML = '<i class="bi bi-trash"></i>';
+                deleteBtn.title = 'Eliminar video';
+                deleteBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    deleteVideo(video.path);
+                });
+
                 const videoCardBody = document.createElement('div');
                 videoCardBody.className = 'card-body';
 
@@ -919,6 +937,7 @@ function displayDownloadedVideos(videos) {
                 videoCardBody.appendChild(videoTitle);
                 videoCardBody.appendChild(videoInfo);
                 videoCard.appendChild(videoPreview);
+                videoCard.appendChild(deleteBtn);
                 videoCard.appendChild(videoCardBody);
                 videoCol.appendChild(videoCard);
                 container.appendChild(videoCol);
@@ -1327,6 +1346,45 @@ async function deleteClip(clipPath, elementId) {
 
     } catch (error) {
         console.error('Error al eliminar clip:', error);
+        alert(`Error: ${error.message}`);
+    }
+}
+
+// Function to delete a downloaded video
+async function deleteVideo(videoPath) {
+    try {
+        const response = await fetch('/api/delete-video', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ videoPath })
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.error || 'Error al eliminar el video');
+        }
+
+        console.log(`Video eliminado: ${videoPath}`);
+
+        await loadVideoLists();
+
+        const statusEl = document.getElementById('downloadStatus');
+        if (statusEl) {
+            const originalText = statusEl.textContent;
+            statusEl.textContent = 'Video eliminado exitosamente';
+            statusEl.style.color = '#28a745';
+
+            setTimeout(() => {
+                statusEl.textContent = originalText;
+                statusEl.style.color = '';
+            }, 2000);
+        }
+
+    } catch (error) {
+        console.error('Error al eliminar video:', error);
         alert(`Error: ${error.message}`);
     }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -118,8 +118,9 @@ footer {
 
 /* .video-container:hover .video-overlay removed as direct video interaction is preferred */
 
-/* Estilos para el botón de eliminar clip */
-.delete-clip-btn {
+/* Estilos para los botones de eliminación */
+.delete-clip-btn,
+.delete-video-btn {
     position: absolute;
     top: 8px;
     /* Adjusted position */
@@ -145,7 +146,8 @@ footer {
     transition: opacity 0.3s, transform 0.2s, background-color 0.3s;
 }
 
-.video-card:hover .delete-clip-btn {
+.video-card:hover .delete-clip-btn,
+.video-card:hover .delete-video-btn {
     /* Show button on card hover */
     opacity: 1;
 }
@@ -186,7 +188,8 @@ footer {
     margin-top: 1rem;
 }
 
-.delete-clip-btn:hover {
+.delete-clip-btn:hover,
+.delete-video-btn:hover {
     opacity: 1;
     transform: scale(1.1);
     background-color: rgba(220, 53, 69, 1);


### PR DESCRIPTION
## Summary
- allow removing downloaded videos from gallery
- add delete-video API endpoint
- support deleting videos on the front-end
- style video delete button

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684473b3bc348323b99c8cf8f1807d5a