### PR TITLE
Improve download speed and final status message

### DIFF
--- a/dist/downloader/index.js
+++ b/dist/downloader/index.js
@@ -552,7 +552,7 @@ class Downloader extends events_1.EventEmitter {
                                     });
                                 });
                                 downloadedPaths.push(finalPath);
-                                yield this.sleep(1000); // Be nice to the server
+                                yield this.sleep(100); // Short pause between downloads
                             }
                         }
                         catch (postError) {
@@ -566,7 +566,7 @@ class Downloader extends events_1.EventEmitter {
                         }
                     }
                     page += 1;
-                    yield this.sleep(2000); // Be nice to the server between pages
+                    yield this.sleep(200); // Short pause between pages
                 }
                 // Emitir evento de finalización de procesamiento de etiqueta
                 this.emit('tagProcessingComplete', {

--- a/public/app.js
+++ b/public/app.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Variables globales
     let currentDownloads = new Map();
     let allDownloadedVideos = [];
+    let downloadsInProgress = false;
 
     // Tab navigation
     const navLinks = document.querySelectorAll('.navbar-nav .nav-link');
@@ -161,6 +162,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('Descarga iniciada:', data);
         showDownloadStatus(`${data.message}`);
 
+        downloadsInProgress = true;
+
         // Almacenar información de la descarga
         if (!currentDownloads.has(data.url)) {
             currentDownloads.set(data.url, {
@@ -217,6 +220,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         updateDownloadList();
 
+        if (currentDownloads.size === 0) {
+            showDownloadStatus('Descargas finalizadas');
+            downloadsInProgress = false;
+        }
+
         // Recargar listas de videos
         loadVideoLists();
     });
@@ -234,6 +242,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         updateDownloadList();
+
+        if (currentDownloads.size === 0) {
+            showDownloadStatus('Descargas finalizadas');
+            downloadsInProgress = false;
+        }
     });
 
     socket.on('directoriesUpdated', (data) => {
@@ -810,7 +823,12 @@ function updateDownloadList() {
     const activeDownloads = Array.from(currentDownloads.values());
 
     if (activeDownloads.length === 0) {
-        downloadStatus.textContent = 'No hay descargas activas';
+        if (downloadsInProgress) {
+            downloadStatus.textContent = 'Descargas finalizadas';
+            downloadsInProgress = false;
+        } else {
+            downloadStatus.textContent = 'No hay descargas activas';
+        }
         return;
     }
 

--- a/src/downloader/index.ts
+++ b/src/downloader/index.ts
@@ -579,7 +579,7 @@ export class Downloader extends EventEmitter {
                             });
 
                             downloadedPaths.push(finalPath);
-                            await this.sleep(1000);  // Be nice to the server
+                            await this.sleep(100);  // Short pause between downloads
                         }
                     } catch (postError: any) {
                         console.error(`Error processing post ${postUrl}:`, postError);
@@ -593,7 +593,7 @@ export class Downloader extends EventEmitter {
                 }
 
                 page += 1;
-                await this.sleep(2000);  // Be nice to the server between pages
+                await this.sleep(200);  // Short pause between pages
             }
 
             // Emitir evento de finalización de procesamiento de etiqueta


### PR DESCRIPTION
## Summary
- shorten delays in downloader to speed up downloads
- show 'Descargas finalizadas' when downloads end

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844768ed550832396d5ce9b34236c7d