### PR TITLE
Enable audio range selection with slider for beat sync

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.css">
 </head>
 
 <body>
@@ -267,6 +268,11 @@
                                 <div id="audioInfo" class="form-text mt-4">Sube un audio para ver su duración.</div>
                             </div>
                         </div>
+                        <div class="row">
+                            <div class="col-12 mb-3">
+                                <audio id="audioPreview" controls class="w-100" style="display: none;"></audio>
+                            </div>
+                        </div>
 
                         <div class="row">
                             <div class="col-md-6 mb-3">
@@ -276,6 +282,11 @@
                             <div class="col-md-6 mb-3">
                                 <label for="audioEndTime" class="form-label">3. Tiempo de fin del audio (segundos):</label>
                                 <input type="number" class="form-control" id="audioEndTime" placeholder="Ej: 120.5" step="0.01">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 mb-3">
+                                <div id="audioRangeSlider"></div>
                             </div>
                         </div>
 
@@ -346,6 +357,8 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/wnumb@1.2.0/wNumb.min.js"></script>
     <script src="https://cdn.socket.io/4.5.0/socket.io.min.js"></script>
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow selecting start and end range of audio when creating beat synced video
- show audio preview and add two-handle slider using `nouislider`
- update JS to sync slider with numeric inputs and vice versa

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bc7581ab08323bb6a103e7c672f1c