### PR TITLE
Improve batch download speed with concurrency

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -154,6 +154,12 @@ function processDownloadedVideos(category_1) {
         type: 'string',
         default: 'output/downloads'
     })
+        .option('concurrency', {
+        alias: 'c',
+        describe: 'Número de descargas simultáneas',
+        type: 'number',
+        default: 3
+    })
         .check((argv) => {
         if (!argv.url && !argv['tags-file']) {
             throw new Error('Debe proporcionar una URL o un archivo de etiquetas');
@@ -163,13 +169,19 @@ function processDownloadedVideos(category_1) {
 }, (argv) => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const app = new app_1.SakugaDownAndClipGen(argv.output);
+        const concurrency = argv.concurrency;
         if (argv['tags-file']) {
             console.log(`Procesando archivo de etiquetas: ${argv['tags-file']}`);
-            yield app['downloader'].processTagsFromFile(argv['tags-file']);
+            yield app['downloader'].processTagsFromFile(argv['tags-file'], argv.output, concurrency);
         }
         else if (argv.url) {
             console.log(`Descargando video desde: ${argv.url}`);
-            yield app['downloader'].downloadVideo(argv.url);
+            if (argv.url.includes('tags=')) {
+                yield app['downloader'].downloadVideosFromTag(argv.url, argv.output, concurrency);
+            }
+            else {
+                yield app['downloader'].downloadVideo(argv.url);
+            }
         }
         console.log('Descarga completada!');
     }

--- a/src/downloader/index.ts
+++ b/src/downloader/index.ts
@@ -424,7 +424,103 @@ export class Downloader extends EventEmitter {
         }
     }
 
-    async downloadVideosFromTag(tagUrl: string, outputDir: string = this.outputDirectory): Promise<string[]> {
+    private async downloadPost(postUrl: string, tag: string, outputDir: string): Promise<string | undefined> {
+        try {
+            const videoUrl = await this.getVideoUrlFromPost(postUrl);
+            if (!videoUrl) return;
+
+            const tagDir = path.join(outputDir, tag);
+            this.createDirectorySafely(tagDir);
+
+            const originalFilename = path.basename(videoUrl);
+            const originalExt = path.extname(originalFilename).toLowerCase();
+            const extension = ['.mp4', '.webm', '.mkv'].includes(originalExt) ? originalExt : '.mp4';
+
+            const fileNumber = this.videoCounter++;
+            const newFilename = `${tag}_${fileNumber}${extension}`;
+            const finalPath = path.join(tagDir, newFilename);
+
+            if (fs.existsSync(finalPath)) {
+                console.log(`File already exists: ${newFilename}`);
+                this.emit('downloadComplete', {
+                    url: videoUrl,
+                    tag,
+                    status: 'complete',
+                    message: `Archivo ya existe: ${newFilename}`,
+                    filePath: path.join(tag, newFilename).replace(/\\/g, '/'),
+                    fileSize: fs.statSync(finalPath).size,
+                    fileName: newFilename
+                });
+                return finalPath;
+            }
+
+            this.emit('downloadProgress', {
+                url: videoUrl,
+                tag,
+                status: 'downloading',
+                message: `Descargando: ${originalFilename} como ${newFilename}`
+            });
+
+            const response = await axios({
+                method: 'GET',
+                url: videoUrl,
+                responseType: 'stream',
+                headers: this.headers
+            });
+
+            const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+            let downloadedSize = 0;
+            let lastProgress = 0;
+
+            const writer = fs.createWriteStream(finalPath);
+
+            response.data.on('data', (chunk: Buffer) => {
+                downloadedSize += chunk.length;
+                if (totalSize > 0) {
+                    const progress = Math.floor((downloadedSize / totalSize) * 100);
+                    if (progress >= lastProgress + 5) {
+                        lastProgress = progress;
+                        this.emit('downloadProgress', {
+                            url: videoUrl,
+                            tag,
+                            status: 'downloading',
+                            message: `Descargando: ${originalFilename} (${progress}%)`,
+                            progress
+                        });
+                    }
+                }
+            });
+
+            response.data.pipe(writer);
+
+            await new Promise<void>((resolve, reject) => {
+                writer.on('finish', resolve);
+                writer.on('error', reject);
+            });
+
+            this.emit('downloadComplete', {
+                url: videoUrl,
+                tag,
+                status: 'complete',
+                message: `Guardado como: ${newFilename}`,
+                filePath: path.join(tag, newFilename).replace(/\\/g, '/'),
+                fileSize: fs.statSync(finalPath).size,
+                fileName: newFilename
+            });
+
+            return finalPath;
+        } catch (err: any) {
+            console.error(`Error processing post ${postUrl}:`, err);
+            this.emit('downloadError', {
+                url: postUrl,
+                tag,
+                status: 'error',
+                message: `Error procesando post: ${err.message}`
+            });
+        }
+    }
+
+    async downloadVideosFromTag(tagUrl: string, outputDir: string = this.outputDirectory, concurrency: number = 3): Promise<string[]> {
         this.videoCounter = 1;  // Reset counter for new tag
         const tag = this.getTagFromUrl(tagUrl);
         let page = 1;
@@ -437,20 +533,21 @@ export class Downloader extends EventEmitter {
         try {
             while (true) {
                 const currentUrl = `${tagUrl}&page=${page}`;
+
+                const postUrls = await this.getVideoPostsFromPage(currentUrl);
+                if (!postUrls.length) {
+                    break;
+                }
+
                 console.log(`Processing page ${page}...`);
 
-                // Emitir evento de progreso
+                // Emitir evento de progreso solo si hay resultados
                 this.emit('downloadProgress', {
                     url: tagUrl,
                     tag,
                     status: 'searching',
                     message: `Procesando página ${page}...`
                 });
-
-                const postUrls = await this.getVideoPostsFromPage(currentUrl);
-                if (!postUrls.length) {
-                    break;
-                }
 
                 // Emitir evento con los posts encontrados
                 this.emit('postsFound', {
@@ -459,137 +556,17 @@ export class Downloader extends EventEmitter {
                     message: `Encontrados ${postUrls.length} posts en página ${page}`
                 });
 
-                for (const postUrl of postUrls) {
-                    try {
-                        const videoUrl = await this.getVideoUrlFromPost(postUrl);
-                        if (videoUrl) {
-                            // Crear directorio específico para el tag de forma segura
-                            const tagDir = path.join(outputDir, tag);
-                            this.createDirectorySafely(tagDir);
+                const batches: string[][] = [];
+                for (let i = 0; i < postUrls.length; i += concurrency) {
+                    batches.push(postUrls.slice(i, i + concurrency));
+                }
 
-                            // Obtener extensión del archivo original
-                            const originalFilename = path.basename(videoUrl);
-                            const originalExt = path.extname(originalFilename).toLowerCase();
-                            // Usar mp4 como formato por defecto, pero respetar la extensión original si es un formato de video
-                            const extension = ['.mp4', '.webm', '.mkv'].includes(originalExt) ? originalExt : '.mp4';
-
-                            // Crear nombre de archivo siguiendo el formato tag_número
-                            const newFilename = `${tag}_${this.videoCounter}${extension}`;
-                            const finalPath = path.join(tagDir, newFilename);
-
-                            // Verificar si el archivo ya existe
-                            if (fs.existsSync(finalPath)) {
-                                console.log(`File already exists: ${newFilename}`);
-                                this.videoCounter += 1;
-
-                                // Emitir evento de descarga completada (para archivos que ya existen)
-                                this.emit('downloadComplete', {
-                                    url: videoUrl,
-                                    tag,
-                                    status: 'complete',
-                                    message: `Archivo ya existe: ${newFilename}`,
-                                    filePath: path.join(tag, newFilename).replace(/\\/g, '/'),
-                                    fileSize: fs.statSync(finalPath).size,
-                                    fileName: newFilename
-                                });
-
-                                downloadedPaths.push(finalPath);
-                                continue;
-                            }
-
-                            // Descargar el archivo
-                            console.log(`Downloading: ${originalFilename} as ${newFilename}`);
-
-                            // Emitir evento de descarga en progreso
-                            this.emit('downloadProgress', {
-                                url: videoUrl,
-                                tag,
-                                status: 'downloading',
-                                message: `Descargando: ${originalFilename} como ${newFilename}`
-                            });
-
-                            const response = await axios({
-                                method: 'GET',
-                                url: videoUrl,
-                                responseType: 'stream',
-                                headers: this.headers
-                            });
-
-                            // Obtener el tamaño total del archivo (si está disponible)
-                            const totalSize = parseInt(response.headers['content-length'] || '0', 10);
-                            let downloadedSize = 0;
-                            let lastProgress = 0;
-
-                            const writer = fs.createWriteStream(finalPath);
-
-                            // Monitorizar el progreso de la descarga
-                            response.data.on('data', (chunk: Buffer) => {
-                                downloadedSize += chunk.length;
-
-                                // Reportar progreso cada 5%
-                                if (totalSize > 0) {
-                                    const progress = Math.floor((downloadedSize / totalSize) * 100);
-                                    if (progress >= lastProgress + 5) {
-                                        lastProgress = progress;
-                                        this.emit('downloadProgress', {
-                                            url: videoUrl,
-                                            tag,
-                                            status: 'downloading',
-                                            message: `Descargando: ${originalFilename} (${progress}%)`,
-                                            progress
-                                        });
-                                    }
-                                }
-                            });
-
-                            response.data.pipe(writer);
-
-                            // Esperar a que termine la descarga
-                            await new Promise<void>((resolve, reject) => {
-                                writer.on('finish', () => {
-                                    console.log(`Saved as: ${newFilename}`);
-                                    this.videoCounter += 1;
-
-                                    // Emitir evento de descarga completada
-                                    this.emit('downloadComplete', {
-                                        url: videoUrl,
-                                        tag,
-                                        status: 'complete',
-                                        message: `Guardado como: ${newFilename}`,
-                                        filePath: path.join(tag, newFilename).replace(/\\/g, '/'),
-                                        fileSize: fs.statSync(finalPath).size,
-                                        fileName: newFilename
-                                    });
-
-                                    resolve();
-                                });
-                                writer.on('error', (err) => {
-                                    console.error('Error downloading video:', err);
-
-                                    // Emitir evento de error
-                                    this.emit('downloadError', {
-                                        url: videoUrl,
-                                        tag,
-                                        status: 'error',
-                                        message: `Error en la descarga: ${err.message}`
-                                    });
-
-                                    reject(err);
-                                });
-                            });
-
-                            downloadedPaths.push(finalPath);
-                            await this.sleep(100);  // Short pause between downloads
-                        }
-                    } catch (postError: any) {
-                        console.error(`Error processing post ${postUrl}:`, postError);
-                        this.emit('downloadError', {
-                            url: postUrl,
-                            tag,
-                            status: 'error',
-                            message: `Error procesando post: ${postError.message}`
-                        });
+                for (const batch of batches) {
+                    const results = await Promise.all(batch.map(p => this.downloadPost(p, tag, outputDir)));
+                    for (const p of results) {
+                        if (p) downloadedPaths.push(p);
                     }
+                    await this.sleep(100);
                 }
 
                 page += 1;
@@ -615,7 +592,7 @@ export class Downloader extends EventEmitter {
         return downloadedPaths;
     }
 
-    async processTagsFromFile(tagsFilePath: string, outputDir: string = this.outputDirectory): Promise<string[]> {
+    async processTagsFromFile(tagsFilePath: string, outputDir: string = this.outputDirectory, concurrency: number = 3): Promise<string[]> {
         try {
             if (!fs.existsSync(tagsFilePath)) {
                 throw new Error(`Tags file '${tagsFilePath}' not found.`);
@@ -637,7 +614,7 @@ export class Downloader extends EventEmitter {
                 }
 
                 const tagUrl = `${this.baseUrl}/post?tags=${trimmedTag}`;
-                const downloadedPaths = await this.downloadVideosFromTag(tagUrl, outputDir);
+                const downloadedPaths = await this.downloadVideosFromTag(tagUrl, outputDir, concurrency);
                 allDownloadedPaths.push(...downloadedPaths);
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,12 @@ yargs(hideBin(process.argv))
                 type: 'string',
                 default: 'output/downloads'
             })
+            .option('concurrency', {
+                alias: 'c',
+                describe: 'Número de descargas simultáneas',
+                type: 'number',
+                default: 3
+            })
             .check((argv) => {
                 if (!argv.url && !argv['tags-file']) {
                     throw new Error('Debe proporcionar una URL o un archivo de etiquetas');
@@ -131,13 +137,18 @@ yargs(hideBin(process.argv))
     }, async (argv) => {
         try {
             const app = new SakugaDownAndClipGen(argv.output as string);
+            const concurrency = argv.concurrency as number;
 
             if (argv['tags-file']) {
                 console.log(`Procesando archivo de etiquetas: ${argv['tags-file']}`);
-                await app['downloader'].processTagsFromFile(argv['tags-file'] as string);
+                await app['downloader'].processTagsFromFile(argv['tags-file'] as string, argv.output as string, concurrency);
             } else if (argv.url) {
                 console.log(`Descargando video desde: ${argv.url}`);
-                await app['downloader'].downloadVideo(argv.url as string);
+                if (argv.url.includes('tags=')) {
+                    await app['downloader'].downloadVideosFromTag(argv.url as string, argv.output as string, concurrency);
+                } else {
+                    await app['downloader'].downloadVideo(argv.url as string);
+                }
             }
 
             console.log('Descarga completada!');


### PR DESCRIPTION
## Summary
- add `--concurrency` option to CLI download command
- parallelise downloads inside `downloadVideosFromTag`
- stop announcing non-existent pages when a tag search is over
- compile TypeScript output

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d75514f8083238b3d875d81fb7715