### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:lts
+
+# Install Python, FFmpeg, Aubio and PySceneDetect
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip ffmpeg aubio-tools && \
+    pip3 install --no-cache-dir scenedetect[opencv] && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+CMD ["node", "dist/index.js", "server"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Una aplicación para descargar videos de Sakugabooru y generar clips automática
     *   **Para la interfaz de línea de comandos (CLI):**
         Consulta la sección "Uso de la CLI" para ver ejemplos de comandos. Si no usaste `npm link`, ejecutarás los comandos con `node dist/index.js <comando> [opciones]`.
 
+## Docker
+
+Tambien es posible ejecutar la aplicacion usando Docker.
+
+### Construir la imagen
+```bash
+docker build -t sakuga-app .
+```
+
+### Ejecutar el contenedor
+```bash
+docker run -p 3000:3000 sakuga-app
+```
+
+Si prefieres usar docker-compose, el proyecto incluye un archivo de ejemplo:
+```bash
+docker-compose up --build
+```
+
+Luego visita http://localhost:3000 en tu navegador.
+
+
 ## Uso
 
 1. Acceder a la interfaz web en http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  sakuga:
+    build: .
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- add Dockerfile with Node, Python, FFmpeg and Aubio
- add docker-compose example exposing port 3000
- document Docker usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ed21f33048323860a4851f58e7523