### PR TITLE
Add delete-all clips button

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -177,6 +177,8 @@ class SakugaDownAndClipGen {
         this.app.post('/api/download-and-clip', this.handlePostDownloadAndClip.bind(this));
         // API para eliminar un clip
         this.app.post('/api/delete-clip', this.handlePostDeleteClip.bind(this));
+        // API para eliminar todos los clips de un video
+        this.app.post('/api/delete-clips-folder', this.handlePostDeleteClipsFolder.bind(this));
         // API para eliminar un video descargado
         this.app.post('/api/delete-video', this.handlePostDeleteVideo.bind(this));
         // API for listing clip folders and renaming videos
@@ -576,6 +578,41 @@ class SakugaDownAndClipGen {
             }
             catch (error) {
                 console.error('Error al eliminar clip:', error);
+                res.status(500).json({ error: error.message });
+            }
+        });
+    }
+    /**
+     * Maneja la solicitud para eliminar todos los clips de un video (carpeta)
+     */
+    handlePostDeleteClipsFolder(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const { folderPath } = req.body;
+                if (!folderPath) {
+                    res.status(400).json({ error: 'Se requiere la carpeta de clips a eliminar' });
+                    return;
+                }
+                const fullFolderPath = path.join(this.clipDirectory, folderPath);
+                console.log(`Intentando eliminar carpeta de clips: ${fullFolderPath}`);
+                if (!fs.existsSync(fullFolderPath) || !fs.statSync(fullFolderPath).isDirectory()) {
+                    res.status(404).json({ error: 'Carpeta no encontrada' });
+                    return;
+                }
+                const normalizedBase = path.normalize(this.clipDirectory);
+                const normalizedFull = path.normalize(fullFolderPath);
+                if (!normalizedFull.startsWith(normalizedBase)) {
+                    res.status(403).json({ error: 'Acceso denegado: ruta de carpeta no permitida' });
+                    return;
+                }
+                fs.rmSync(fullFolderPath, { recursive: true, force: true });
+                console.log(`Carpeta de clips eliminada: ${folderPath}`);
+                const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
+                this.io.emit('directoriesUpdated', { type: 'clips', contents: clips });
+                res.json({ success: true, message: 'Clips eliminados correctamente' });
+            }
+            catch (error) {
+                console.error('Error al eliminar carpeta de clips:', error);
                 res.status(500).json({ error: error.message });
             }
         });

--- a/public/app.js
+++ b/public/app.js
@@ -1076,13 +1076,29 @@ function displayGeneratedClips(clips) {
         headerRow.className = 'row mb-2 mt-4';
         headerRow.innerHTML = `
             <div class="col-12 d-flex justify-content-between align-items-center">
-                <h5 class="mb-0">${videoName} <span class="badge bg-secondary">${videoClips.length} clips</span></h5>
+                <div>
+                    <h5 class="mb-0 d-inline">${videoName} <span class="badge bg-secondary">${videoClips.length} clips</span></h5>
+                    <button class="btn btn-sm btn-danger ms-2 delete-all-clips-btn" data-folder="${videoName}" title="Borrar todos los clips">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
                 <div class="pagination-info">
                     <small class="text-muted">Página ${currentPage} de ${totalPages}</small>
                 </div>
             </div>
         `;
         videoSection.appendChild(headerRow);
+
+        const deleteAllBtn = headerRow.querySelector('.delete-all-clips-btn');
+        if (deleteAllBtn) {
+            deleteAllBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const folder = deleteAllBtn.getAttribute('data-folder');
+                if (folder) {
+                    deleteClipsFolder(folder);
+                }
+            });
+        }
 
         // Create pagination controls if needed
         if (totalPages > 1) {
@@ -1460,6 +1476,32 @@ async function deleteVideo(videoPath) {
 
     } catch (error) {
         console.error('Error al eliminar video:', error);
+        alert(`Error: ${error.message}`);
+    }
+}
+
+// Function to delete all clips inside a folder (video)
+async function deleteClipsFolder(folderPath) {
+    if (!confirm(`¿Eliminar todos los clips de ${folderPath}?`)) return;
+    try {
+        const response = await fetch('/api/delete-clips-folder', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ folderPath })
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.error || 'Error al eliminar los clips');
+        }
+
+        console.log(`Carpeta de clips eliminada: ${folderPath}`);
+        videoPaginationState.delete(folderPath);
+        await loadVideoLists();
+    } catch (error) {
+        console.error('Error al eliminar carpeta de clips:', error);
         alert(`Error: ${error.message}`);
     }
 }


### PR DESCRIPTION
## Summary
- allow deleting all clips belonging to a video folder
- expose API endpoint `/api/delete-clips-folder`
- wire up delete-all button per video section in the UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687507ac543c832391f38b817fae3c21