### PR TITLE
Add multi-select deletion for generated clips

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -383,3 +383,15 @@ footer {
     /* bi-pause-fill */
     opacity: 1;
 }
+
+/* Selection styles */
+.clip-select-checkbox {
+    position: absolute;
+    left: 8px;
+    top: 8px;
+    z-index: 11;
+}
+
+.clip-selected {
+    border: 3px solid #0d6efd;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -390,6 +390,10 @@ footer {
     left: 8px;
     top: 8px;
     z-index: 11;
+    width: 1.25rem;
+    height: 1.25rem;
+    transform: scale(1.3);
+    transform-origin: top left;
 }
 
 .clip-selected {


### PR DESCRIPTION
## Summary
- implement clip selection tracking and bulk deletion
- add checkboxes and selection styles for clip cards
- show 'Eliminar seleccionados' buttons on clip groups

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68751487989c8323aa86abcd4d27a3b2