### PR TITLE
Add clip duration counter

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -57,13 +57,14 @@ const fs = __importStar(require("fs"));
 const http_1 = __importDefault(require("http"));
 const socket_io_1 = require("socket.io");
 const child_process_1 = require("child_process");
+const ffprobe_static_1 = __importDefault(require("ffprobe-static"));
 class SakugaDownAndClipGen {
     constructor(downloadDirectory = 'output/downloads', clipDirectory = 'output/clips', randomNamesDirectory = 'output/random_names', tempAudioDirectory = 'output/temp_audio', beatSyncedVideosDirectory = 'output/beat_synced_videos', port = 3000) {
         this.downloader = new downloader_1.Downloader('https://www.sakugabooru.com', downloadDirectory);
         this.clipGenerator = new clipGenerator_1.ClipGenerator(clipDirectory); // FFMPEG_PATH and FFPROBE_PATH are resolved within ClipGenerator
         // Define FFMPEG paths locally
         const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
-        const FFPROBE_PATH = process.env.FFPROBE_PATH || 'ffprobe';
+        const FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe_static_1.default.path;
         this.audioAnalyzer = new audioAnalyzer_1.AudioAnalyzer(FFMPEG_PATH);
         this.beatSyncedVideosDirectory = beatSyncedVideosDirectory;
         this.beatSyncGenerator = new beatSyncGenerator_1.BeatSyncGenerator(FFMPEG_PATH, FFPROBE_PATH, this.beatSyncedVideosDirectory);
@@ -798,7 +799,7 @@ class SakugaDownAndClipGen {
     getVideoDurationFFprobe(videoPath) {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((resolve, reject) => {
-                const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
+                const ffprobePath = process.env.FFPROBE_PATH || ffprobe_static_1.default.path;
                 const args = [
                     '-v', 'error',
                     '-show_entries', 'format=duration',

--- a/dist/clipGenerator/index.js
+++ b/dist/clipGenerator/index.js
@@ -41,15 +41,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ClipGenerator = void 0;
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const child_process_1 = require("child_process");
 const child_process_2 = require("child_process");
+const ffprobe_static_1 = __importDefault(require("ffprobe-static"));
 // Configuración de rutas para FFmpeg
 let FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
-let FFPROBE_PATH = process.env.FFPROBE_PATH || 'ffprobe';
+let FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe_static_1.default.path;
 // Función para verificar si un ejecutable está disponible
 function isExecutableAvailable(executableName) {
     try {
@@ -104,12 +108,13 @@ function findFFmpegPath() {
 const ffmpegPath = findFFmpegPath();
 if (ffmpegPath) {
     FFMPEG_PATH = ffmpegPath;
-    FFPROBE_PATH = ffmpegPath.replace('ffmpeg.exe', 'ffprobe.exe');
+    FFPROBE_PATH = process.env.FFPROBE_PATH || ffmpegPath.replace('ffmpeg.exe', 'ffprobe.exe');
     console.log(`FFmpeg detectado en: ${FFMPEG_PATH}`);
     console.log(`FFprobe detectado en: ${FFPROBE_PATH}`);
 }
 else {
     console.warn('No se pudo detectar FFmpeg automáticamente. Se intentará usar los comandos "ffmpeg" y "ffprobe" directamente.');
+    FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe_static_1.default.path;
 }
 class ClipGenerator {
     constructor(outputDirectory = 'output/clips', ffmpegPath, ffprobePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.6.2",
         "cheerio": "^1.0.0-rc.12",
         "express": "^5.1.0",
+        "ffprobe-static": "^3.1.0",
         "multer": "^1.4.5-lts.1",
         "socket.io": "^4.8.1",
         "yargs": "^17.7.2"
@@ -1005,6 +1006,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "express": "^5.1.0",
     "socket.io": "^4.8.1",
     "yargs": "^17.7.2",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "ffprobe-static": "^3.1.0"
   },
   "devDependencies": {
     "@types/multer": "^1.4.11",

--- a/public/app.js
+++ b/public/app.js
@@ -1736,6 +1736,10 @@ async function generateClips(videoPath, minDuration, maxDuration, threshold, use
             const videoName = videoPath.split('/').pop();
             const folderName = videoName.replace(/\.[^/.]+$/, '');
 
+            const totalDuration = Array.isArray(data.clipInfos)
+                ? data.clipInfos.reduce((sum, c) => sum + (c.duration || 0), 0)
+                : 0;
+
             const group = document.createElement('div');
             group.id = `clips-group-gen-${folderName.replace(/[^a-zA-Z0-9]/g, '-')}`;
 
@@ -1744,13 +1748,16 @@ async function generateClips(videoPath, minDuration, maxDuration, threshold, use
             const slugGen = folderName.replace(/[^a-zA-Z0-9]/g, '-');
             headerRow.innerHTML = `
                 <div class="col-12 d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0 d-inline">${videoName} <span class="badge bg-secondary">${data.clipPaths.length} clips</span></h5>
-                    <button class="btn btn-sm btn-danger ms-2 delete-all-clips-btn" data-folder="${folderName}" title="Borrar todos los clips">
-                        <i class="bi bi-trash"></i>
-                    </button>
-                    <button class="btn btn-sm btn-warning ms-2 delete-selected-btn" id="delete-selected-btn-${slugGen}" style="display:none;">
-                        <i class="bi bi-trash"></i> Eliminar seleccionados (<span class="selected-count">0</span>)
-                    </button>
+                    <div>
+                        <h5 class="mb-0 d-inline">${videoName} <span class="badge bg-secondary">${data.clipPaths.length} clips</span></h5>
+                        <button class="btn btn-sm btn-danger ms-2 delete-all-clips-btn" data-folder="${folderName}" title="Borrar todos los clips">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                        <button class="btn btn-sm btn-warning ms-2 delete-selected-btn" id="delete-selected-btn-${slugGen}" style="display:none;">
+                            <i class="bi bi-trash"></i> Eliminar seleccionados (<span class="selected-count">0</span>)
+                        </button>
+                        <div><small class="text-muted">Duración total: ${Math.round(totalDuration)} segundos</small></div>
+                    </div>
                 </div>`;
             group.appendChild(headerRow);
 
@@ -1860,6 +1867,10 @@ async function generateClipsFromFolder(folderPath, minDuration, maxDuration, thr
                     const videoName = result.videoPath.split('/').pop();
                     const folderName = videoName.replace(/\.[^/.]+$/, '');
 
+                    const totalDuration = Array.isArray(result.clipInfos)
+                        ? result.clipInfos.reduce((sum, c) => sum + (c.duration || 0), 0)
+                        : 0;
+
                     const group = document.createElement('div');
                     group.id = `clips-group-gen-${folderName.replace(/[^a-zA-Z0-9]/g, '-')}`;
 
@@ -1868,13 +1879,16 @@ async function generateClipsFromFolder(folderPath, minDuration, maxDuration, thr
                     const slugFolder = folderName.replace(/[^a-zA-Z0-9]/g, '-');
                     headerRow.innerHTML = `
                         <div class="col-12 d-flex justify-content-between align-items-center">
-                            <h5 class="mb-0 d-inline">${videoName} <span class="badge bg-secondary">${result.clipPaths.length} clips</span></h5>
-                            <button class="btn btn-sm btn-danger ms-2 delete-all-clips-btn" data-folder="${folderName}" title="Borrar todos los clips">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                            <button class="btn btn-sm btn-warning ms-2 delete-selected-btn" id="delete-selected-btn-${slugFolder}" style="display:none;">
-                                <i class="bi bi-trash"></i> Eliminar seleccionados (<span class="selected-count">0</span>)
-                            </button>
+                            <div>
+                                <h5 class="mb-0 d-inline">${videoName} <span class="badge bg-secondary">${result.clipPaths.length} clips</span></h5>
+                                <button class="btn btn-sm btn-danger ms-2 delete-all-clips-btn" data-folder="${folderName}" title="Borrar todos los clips">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <button class="btn btn-sm btn-warning ms-2 delete-selected-btn" id="delete-selected-btn-${slugFolder}" style="display:none;">
+                                    <i class="bi bi-trash"></i> Eliminar seleccionados (<span class="selected-count">0</span>)
+                                </button>
+                                <div><small class="text-muted">Duración total: ${Math.round(totalDuration)} segundos</small></div>
+                            </div>
                         </div>`;
                     group.appendChild(headerRow);
 

--- a/public/app.js
+++ b/public/app.js
@@ -1121,6 +1121,7 @@ function displayGeneratedClips(clips) {
 
         let currentPage = videoPaginationState.get(videoName).currentPage;
         const totalPages = Math.ceil(videoClips.length / CLIPS_PER_PAGE);
+        const totalDuration = videoClips.reduce((sum, c) => sum + (c.duration || 0), 0);
 
         // Adjust current page if it's now invalid (happens when deleting clips)
         if (currentPage > totalPages && totalPages > 0) {
@@ -1151,6 +1152,7 @@ function displayGeneratedClips(clips) {
                     <button class="btn btn-sm btn-warning ms-2 delete-selected-btn" id="delete-selected-btn-${slug}" style="display:none;">
                         <i class="bi bi-trash"></i> Eliminar seleccionados (<span class="selected-count">0</span>)
                     </button>
+                    <div><small class="text-muted">Duración total: ${Math.round(totalDuration)} segundos</small></div>
                 </div>
                 <div class="pagination-info">
                     <small class="text-muted">Página ${currentPage} de ${totalPages}</small>

--- a/src/app.ts
+++ b/src/app.ts
@@ -214,10 +214,15 @@ export class SakugaDownAndClipGen {
         res.json(downloads);
     }
 
-    private handleGetClips(req: express.Request, res: express.Response): void {
-        // Only return video files to avoid showing directories or full videos
-        const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
-        res.json(clips);
+    private async handleGetClips(req: express.Request, res: express.Response): Promise<void> {
+        try {
+            const clips = (await this.getDirectoryContentsWithDuration(this.clipDirectory))
+                .filter(item => item.type === 'video');
+            res.json(clips);
+        } catch (error: any) {
+            console.error('Error obteniendo clips:', error);
+            res.status(500).json({ error: error.message });
+        }
     }
 
     private async handlePostDownload(req: express.Request, res: express.Response): Promise<void> {
@@ -375,7 +380,7 @@ export class SakugaDownAndClipGen {
             await processDirectory(videosDirectory);
 
             // Notificar la actualización de la lista de clips
-            const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
+            const clips = (await this.getDirectoryContentsWithDuration(this.clipDirectory)).filter(item => item.type === 'video');
             this.io.emit('directoriesUpdated', { type: 'clips', contents: clips });
 
             res.json({ success: true, results });
@@ -634,7 +639,7 @@ export class SakugaDownAndClipGen {
             }
 
             // Actualizar la lista de clips y notificar a los clientes
-            const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
+            const clips = (await this.getDirectoryContentsWithDuration(this.clipDirectory)).filter(item => item.type === 'video');
             this.io.emit('directoriesUpdated', { type: 'clips', contents: clips });
 
             res.json({ success: true, message: 'Clip eliminado correctamente' });
@@ -675,7 +680,7 @@ export class SakugaDownAndClipGen {
             fs.rmSync(fullFolderPath, { recursive: true, force: true });
             console.log(`Carpeta de clips eliminada: ${folderPath}`);
 
-            const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
+            const clips = (await this.getDirectoryContentsWithDuration(this.clipDirectory)).filter(item => item.type === 'video');
             this.io.emit('directoriesUpdated', { type: 'clips', contents: clips });
 
             res.json({ success: true, message: 'Clips eliminados correctamente' });
@@ -856,6 +861,108 @@ export class SakugaDownAndClipGen {
         };
 
         processDirectory(directory);
+        return contents;
+    }
+
+    /**
+     * Obtiene la duración de un video utilizando FFprobe
+     */
+    private async getVideoDurationFFprobe(videoPath: string): Promise<number> {
+        return new Promise((resolve, reject) => {
+            const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
+            const args = [
+                '-v', 'error',
+                '-show_entries', 'format=duration',
+                '-of', 'default=noprint_wrappers=1:nokey=1',
+                videoPath
+            ];
+
+            const ffprobeProcess = spawn(ffprobePath, args);
+            let stdoutData = '';
+            let stderrData = '';
+
+            ffprobeProcess.stdout.on('data', (data) => {
+                stdoutData += data.toString();
+            });
+
+            ffprobeProcess.stderr.on('data', (data) => {
+                stderrData += data.toString();
+            });
+
+            ffprobeProcess.on('close', (code) => {
+                if (code === 0) {
+                    const duration = parseFloat(stdoutData.trim());
+                    if (!isNaN(duration)) {
+                        resolve(duration);
+                    } else {
+                        reject(new Error('Could not parse video duration'));
+                    }
+                } else {
+                    console.error('FFprobe stderr:', stderrData);
+                    reject(new Error(`FFprobe process exited with code ${code}`));
+                }
+            });
+
+            ffprobeProcess.on('error', (err) => {
+                reject(new Error(`Failed to start FFprobe process: ${err.message}`));
+            });
+        });
+    }
+
+    /**
+     * Obtiene el contenido de un directorio e incluye la duración de los videos
+     */
+    private async getDirectoryContentsWithDuration(
+        directory: string,
+        baseFolder: string = ''
+    ): Promise<{ name: string, path: string, type: string, size: number, duration?: number }[]> {
+        const contents: { name: string, path: string, type: string, size: number, duration?: number }[] = [];
+
+        if (!fs.existsSync(directory)) {
+            return contents;
+        }
+
+        const processDirectory = async (dir: string, relativePath: string = '') => {
+            const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+            for (const entry of entries) {
+                const fullPath = path.join(dir, entry.name);
+                let entryRelativePath: string;
+
+                if (baseFolder) {
+                    entryRelativePath = path.join(baseFolder, relativePath, entry.name);
+                } else {
+                    entryRelativePath = relativePath ? path.join(relativePath, entry.name) : entry.name;
+                }
+
+                if (entry.isDirectory()) {
+                    contents.push({
+                        name: entry.name,
+                        path: entryRelativePath,
+                        type: 'directory',
+                        size: 0
+                    });
+                    await processDirectory(fullPath, path.join(relativePath, entry.name));
+                } else if (entry.isFile() && /\.(mp4|webm|mkv)$/i.test(entry.name)) {
+                    const stats = fs.statSync(fullPath);
+                    let duration = 0;
+                    try {
+                        duration = await this.getVideoDurationFFprobe(fullPath);
+                    } catch (e) {
+                        console.warn(`No se pudo obtener la duración de ${fullPath}:`, e);
+                    }
+                    contents.push({
+                        name: entry.name,
+                        path: entryRelativePath,
+                        type: 'video',
+                        size: stats.size,
+                        duration
+                    });
+                }
+            }
+        };
+
+        await processDirectory(directory);
         return contents;
     }
 
@@ -1049,7 +1156,7 @@ export class SakugaDownAndClipGen {
             throw error; // Re-throw the error to be handled by the caller
         }
         // Notificar la actualización de la lista de clips
-        const clips = this.getDirectoryContents(this.clipDirectory).filter(item => item.type === 'video');
+        const clips = (await this.getDirectoryContentsWithDuration(this.clipDirectory)).filter(item => item.type === 'video');
         this.io.emit('directoriesUpdated', { type: 'clips', contents: clips });
         return resultsMap; // Return the map of results
     }    /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import http from 'http';
 import { Server, Socket } from 'socket.io';
 import { spawn } from 'child_process';
+import ffprobe from 'ffprobe-static';
 
 // Interface for requests with file uploads
 interface RequestWithFile extends Request {
@@ -43,7 +44,7 @@ export class SakugaDownAndClipGen {
 
         // Define FFMPEG paths locally
         const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
-        const FFPROBE_PATH = process.env.FFPROBE_PATH || 'ffprobe';
+        const FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe.path;
 
         this.audioAnalyzer = new AudioAnalyzer(FFMPEG_PATH);
         this.beatSyncedVideosDirectory = beatSyncedVideosDirectory;
@@ -882,7 +883,7 @@ export class SakugaDownAndClipGen {
      */
     private async getVideoDurationFFprobe(videoPath: string): Promise<number> {
         return new Promise((resolve, reject) => {
-            const ffprobePath = process.env.FFPROBE_PATH || 'ffprobe';
+            const ffprobePath = process.env.FFPROBE_PATH || ffprobe.path;
             const args = [
                 '-v', 'error',
                 '-show_entries', 'format=duration',

--- a/src/clipGenerator/index.ts
+++ b/src/clipGenerator/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { execSync } from 'child_process';
+import ffprobe from 'ffprobe-static';
 
 /**
  * Opciones para la detección de escenas
@@ -14,7 +15,7 @@ export interface SceneDetectionOptions {
 
 // Configuración de rutas para FFmpeg
 let FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
-let FFPROBE_PATH = process.env.FFPROBE_PATH || 'ffprobe';
+let FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe.path;
 
 // Función para verificar si un ejecutable está disponible
 function isExecutableAvailable(executableName: string): boolean {
@@ -72,11 +73,12 @@ function findFFmpegPath(): string | null {
 const ffmpegPath = findFFmpegPath();
 if (ffmpegPath) {
     FFMPEG_PATH = ffmpegPath;
-    FFPROBE_PATH = ffmpegPath.replace('ffmpeg.exe', 'ffprobe.exe');
+    FFPROBE_PATH = process.env.FFPROBE_PATH || ffmpegPath.replace('ffmpeg.exe', 'ffprobe.exe');
     console.log(`FFmpeg detectado en: ${FFMPEG_PATH}`);
     console.log(`FFprobe detectado en: ${FFPROBE_PATH}`);
 } else {
     console.warn('No se pudo detectar FFmpeg automáticamente. Se intentará usar los comandos "ffmpeg" y "ffprobe" directamente.');
+    FFPROBE_PATH = process.env.FFPROBE_PATH || ffprobe.path;
 }
 
 export class ClipGenerator {

--- a/src/types/ffprobe-static.d.ts
+++ b/src/types/ffprobe-static.d.ts
@@ -1,0 +1,4 @@
+declare module 'ffprobe-static' {
+    const ffprobe: { path: string };
+    export default ffprobe;
+}


### PR DESCRIPTION
## Summary
- add helper functions to collect durations with FFprobe
- report clip durations in API responses
- show total clip duration per folder in the UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68751c00fc648323843b45578c300d2f