### PR TITLE
Improve download UX with persistence, toasts and drag‑and‑drop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,6 +98,7 @@
                         <div id="downloadProgress" class="progress-bar progress-bar-striped progress-bar-animated"
                             role="progressbar" style="width: 0%"></div>
                     </div>
+                    <div id="currentDownloadsList" class="list-group mb-3"></div>
                     <div id="downloadResults" class="list-group"></div>
                 </div>
             </div>
@@ -196,9 +197,8 @@
                                         <option value="24">24 clips</option>
                                         <option value="48">48 clips</option>
                                     </select>
-                                    <small class="text-muted ms-3"
-                                        title="Usa Ctrl+← y Ctrl+→ para navegar entre páginas">
-                                        <i class="bi bi-info-circle"></i> Atajos: Ctrl+← / Ctrl+→
+                                    <small id="paginationShortcuts" class="text-muted ms-3" data-bs-toggle="tooltip" data-bs-html="true" title="Ctrl+←: página anterior&lt;br&gt;Ctrl+→: página siguiente">
+                                        <i class="bi bi-info-circle"></i> Atajos de teclado
                                     </small>
                                 </div>
                                 <button id="refreshClipsBtn" class="btn btn-outline-secondary btn-sm">
@@ -206,7 +206,7 @@
                                 </button>
                             </div>
                             <div id="generatedClips" class="browser-content row"></div>
-                            <div id="noClipsMessage" class="text-center p-5">
+                            <div id="noClipsMessage" class="text-center p-5" style="display: none;">
                                 <i class="bi bi-film fs-1"></i>
                                 <p class="mt-3">No hay clips generados</p>
                             </div>
@@ -358,6 +358,8 @@
             <p>SakugaVideos - Downloader & Clip Generator</p>
         </div>
     </footer>
+
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" id="toastContainer"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js"></script>


### PR DESCRIPTION
## Summary
- Persist UI state (active tab, last tags, selected folder, clips-per-page) in localStorage
- Add cancellable download list with Bootstrap toasts for status messages
- Support drag-and-drop for URLs and audio files and expose keyboard shortcuts via tooltip

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899bd53efa08323a0103bf1aae95a20